### PR TITLE
feat(walkin, rbac): format walkin list date, add marquee scroll to ce…

### DIFF
--- a/README.md
+++ b/README.md
@@ -623,3 +623,7 @@ All endpoints require a Bearer JWT token. Full Swagger documentation is availabl
   - On status update, the controller compares today's midnight with the `lastStatusChangeDate` at midnight. If they match, the request is rejected.
   - After a successful status change, `lastStatusChangeDate` is set to the current timestamp.
 - **UI Feedback:** In `WalkinList.jsx`, the status dropdown is **disabled** for walk-ins that were changed today, showing visual feedback with gray border (60% opacity).
+
+### Accessible Employees Dropdown Updates (June 2026)
+- **Admin Accounts Exclusion:** Admin accounts (Super Admin, Admin, HR Admin, Cluster Admin, and Store Admin) are now explicitly excluded/filtered out from the `/api/admin/accessible-employees` response. This prevents administrators from cluttering the standard employee selection dropdown lists.
+- **Dynamic Store Filtering Resolution:** The `/api/admin/accessible-employees` endpoint has been upgraded to support dynamic, multi-store query resolution. It accepts any of `storeId`, `store`, or `locCode` parameters from client applications (such as Flutter). The backend automatically translates these values (whether they are Mongo ObjectIds, Location Codes, or Working Branch names) to resolve the correct store branch and list only its mapped employees, solving filtering issues for multi-store roles (Cluster, HR, and Admin).

--- a/backend/controllers/DestinationController.js
+++ b/backend/controllers/DestinationController.js
@@ -857,18 +857,35 @@ export const getAccessibleEmployees = async (req, res) => {
             return res.status(401).json({ message: "Unauthorized" });
         }
         
-        // Optional storeId filter
-        const { storeId } = req.query;
+        // Support any of storeId, store, or locCode query parameters from clients (like Flutter)
+        const storeParam = req.query.storeId || req.query.store || req.query.locCode;
+        let resolvedStore = null;
+        
+        if (storeParam) {
+            if (mongoose.Types.ObjectId.isValid(storeParam)) {
+                resolvedStore = await Branch.findById(storeParam);
+            }
+            if (!resolvedStore) {
+                resolvedStore = await Branch.findOne({
+                    $or: [
+                        { locCode: storeParam },
+                        { workingBranch: storeParam },
+                        { branchName: storeParam }
+                    ]
+                });
+            }
+        }
+
         let employeeIds = await getAccessibleEmployeeIds(req.admin.userId);
         
         let query = { _id: { $in: employeeIds }, status: 'Active' };
         
-        if (storeId) {
+        if (resolvedStore) {
             const accessibleStoreIds = await getAccessibleStoreIds(req.admin.userId);
-            if (!accessibleStoreIds.includes(storeId)) {
+            if (!accessibleStoreIds.includes(resolvedStore._id.toString())) {
                 return res.status(403).json({ message: "Access denied to this store's employees" });
             }
-            query.storeId = storeId;
+            query.storeId = resolvedStore._id;
         }
 
         let employees = await Employee.find(query);
@@ -879,10 +896,11 @@ export const getAccessibleEmployees = async (req, res) => {
             const branches = await Branch.find({ _id: { $in: accessibleStoreIds } });
             
             let userQuery = {};
-            if (storeId) {
-                const targetBranch = branches.find(b => b._id.toString() === storeId.toString());
-                if (targetBranch) {
-                    userQuery.locCode = targetBranch.locCode;
+            if (resolvedStore) {
+                // Ensure the resolved store is within accessible stores
+                const isAccessible = branches.some(b => b._id.toString() === resolvedStore._id.toString());
+                if (isAccessible) {
+                    userQuery.locCode = resolvedStore.locCode;
                 } else {
                     userQuery.locCode = "NON_EXISTENT";
                 }
@@ -906,6 +924,23 @@ export const getAccessibleEmployees = async (req, res) => {
                 status: 'Active'
             }));
         }
+
+        // --- FILTER OUT ADMINS (from showing up in the Employee dropdown) ---
+        const adminsList = await Admin.find({}).select('email EmpId employeeId').lean();
+        const adminEmails = new Set(adminsList.map(a => a.email?.toLowerCase().trim()).filter(Boolean));
+        const adminEmpIds = new Set([
+            ...adminsList.map(a => a.EmpId?.toLowerCase().trim()).filter(Boolean),
+            ...adminsList.map(a => (a.employeeId || '')?.toLowerCase().trim()).filter(Boolean)
+        ]);
+
+        employees = employees.filter(emp => {
+            const empEmail = emp.email?.toLowerCase().trim();
+            const empId = (emp.employeeId || emp.empID)?.toLowerCase().trim();
+            
+            // Exclude if the email or employee ID matches any admin record
+            const isMatch = adminEmails.has(empEmail) || adminEmpIds.has(empId);
+            return !isMatch;
+        });
 
         res.status(200).json({ employees });
     } catch (error) {

--- a/backend/routes/AdminRoute.js
+++ b/backend/routes/AdminRoute.js
@@ -34,7 +34,7 @@ router.get('/accessible-stores', MiddilWare, getAccessibleStores);
  *   get:
  *     tags: [Admin]
  *     summary: Retrieve accessible employees for admin
- *     description: Returns a list of employees accessible to the logged-in admin based on their role and assigned branches.
+ *     description: Returns a list of employees accessible to the logged-in admin based on their role and assigned branches. Admins are filtered out from this list.
  *     security:
  *       - bearerAuth: []
  *     parameters:
@@ -42,7 +42,17 @@ router.get('/accessible-stores', MiddilWare, getAccessibleStores);
  *         name: storeId
  *         schema:
  *           type: string
- *         description: Optional store ID to filter employees
+ *         description: Optional store filter (can be storeId/ObjectId, workingBranch name, or locCode)
+ *       - in: query
+ *         name: store
+ *         schema:
+ *           type: string
+ *         description: Optional store filter alias (workingBranch name or locCode)
+ *       - in: query
+ *         name: locCode
+ *         schema:
+ *           type: string
+ *         description: Optional store filter alias (locCode)
  *     responses:
  *       200:
  *         description: A list of employees

--- a/frontend/src/pages/Walkin/WalkinList.jsx
+++ b/frontend/src/pages/Walkin/WalkinList.jsx
@@ -990,28 +990,40 @@ const WalkinList = () => {
                                                             onMouseLeave={e => e.currentTarget.style.background = '#fff'}
                                                         >
                                                             <td style={{ padding: '11px 12px', textAlign: 'center', color: '#9ca3af' }}>{indexFirst + index + 1}</td>
-                                                            <td style={{ padding: '11px 12px', whiteSpace: 'nowrap', color: '#374151' }}>{w.date}</td>
+                                                            <td style={{ padding: '11px 12px', whiteSpace: 'nowrap', color: '#374151' }}>{safeDateOnly(w.date)}</td>
                                                             <td style={{ padding: '11px 12px', color: '#111827', fontWeight: 500, whiteSpace: 'nowrap' }}>{w.customerName}</td>
                                                             <td style={{ padding: '11px 12px', whiteSpace: 'nowrap', color: '#374151' }}>+91 {w.contact}</td>
                                                             <td style={{ padding: '11px 12px', whiteSpace: 'nowrap', color: '#374151' }}>{w.functionDate}</td>
                                                             <td style={{ padding: '11px 12px', whiteSpace: 'nowrap', color: '#374151' }}>{w.store}</td>
                                                             <td style={{ padding: '11px 12px', whiteSpace: 'nowrap', color: '#374151' }}>{w.staff}</td>
-                                                            <td style={{ padding: '11px 12px', whiteSpace: 'nowrap', color: '#374151' }}>{w.category}</td>
-                                                            <td style={{ padding: '11px 12px', whiteSpace: 'nowrap', color: '#374151' }}>
-                                                                {w.subCategory}
-                                                                {w.attachment && (
-                                                                    <a 
-                                                                        href={w.attachment} 
-                                                                        target="_blank" 
-                                                                        rel="noopener noreferrer" 
-                                                                        style={{ marginLeft: '6px', color: '#2563eb', textDecoration: 'none', display: 'inline-flex', alignItems: 'center' }}
-                                                                        title={`View attachment: ${w.attachmentName || 'Attachment'}`}
-                                                                    >
-                                                                        📎
-                                                                    </a>
-                                                                )}
+                                                            <td style={{ padding: '11px 12px', color: '#374151' }}>
+                                                                <div className="walkin-marquee-container" style={{ width: '100px' }}>
+                                                                    <span className="walkin-marquee-text walkin-anim-scroll">{w.category || '–'}</span>
+                                                                </div>
                                                             </td>
-                                                            <td style={{ padding: '11px 12px', color: '#6b7280', maxWidth: '120px', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }} title={w.remarks}>{w.remarks || '–'}</td>
+                                                            <td style={{ padding: '11px 12px', color: '#374151', whiteSpace: 'nowrap' }}>
+                                                                <div style={{ display: 'inline-flex', alignItems: 'center' }}>
+                                                                    <div className="walkin-marquee-container" style={{ width: '100px' }}>
+                                                                        <span className="walkin-marquee-text walkin-anim-scroll">{w.subCategory || '–'}</span>
+                                                                    </div>
+                                                                    {w.attachment && (
+                                                                        <a 
+                                                                            href={w.attachment} 
+                                                                            target="_blank" 
+                                                                            rel="noopener noreferrer" 
+                                                                            style={{ marginLeft: '6px', color: '#2563eb', textDecoration: 'none', display: 'inline-flex', alignItems: 'center' }}
+                                                                            title={`View attachment: ${w.attachmentName || 'Attachment'}`}
+                                                                        >
+                                                                            📎
+                                                                        </a>
+                                                                    )}
+                                                                </div>
+                                                            </td>
+                                                            <td style={{ padding: '11px 12px', color: '#6b7280' }}>
+                                                                <div className="walkin-marquee-container" style={{ width: '100px' }} title={w.remarks}>
+                                                                    <span className="walkin-marquee-text walkin-anim-scroll">{w.remarks || '–'}</span>
+                                                                </div>
+                                                            </td>
                                                             <td style={{ padding: '11px 12px', textAlign: 'center', color: '#374151' }}>{w.repeatCount}</td>
                                                             <td style={{ padding: '11px 12px', textAlign: 'center' }}>
                                                                 <select
@@ -1104,7 +1116,28 @@ const WalkinList = () => {
                                 </>
                             )}
                         </div>
-                        <style>{`@keyframes walkin-spin{to{transform:rotate(360deg)}}`}</style>
+                        <style>{`
+                            @keyframes walkin-spin { to { transform: rotate(360deg); } }
+                            .walkin-marquee-container {
+                                overflow: hidden;
+                                white-space: nowrap;
+                                display: block;
+                            }
+                            .walkin-marquee-text {
+                                display: inline-block;
+                                min-width: 100%;
+                            }
+                            .walkin-marquee-container:hover .walkin-marquee-text {
+                                animation-play-state: paused;
+                            }
+                            .walkin-anim-scroll {
+                                animation: walkin-marquee-scroll 8s linear infinite;
+                            }
+                            @keyframes walkin-marquee-scroll {
+                                0%, 15% { transform: translateX(0); }
+                                85%, 100% { transform: translateX(calc(-100% + 100px)); }
+                            }
+                        `}</style>
                     </>
                 )}
             </div>


### PR DESCRIPTION
…lls, exclude admins from employees dropdown, resolve multi-store filters

- Walkin List View: Format date using safeDateOnly to remove time portion
- Walkin Table layout: Standardize Category, Sub Category, and Remarks columns to 100px and add continuous left marquee auto-scroll with pause-on-hover
- RBAC / Employees Dropdown: Filter out admin accounts from showing in employees dropdown list
- API: Enable dynamic query resolution for storeId, store, and locCode parameters to support multi-store role filtering
- Docs: Update Swagger annotations and README.md with the API updates

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The employee dropdown now supports multiple store filter parameters for improved flexibility.

* **Bug Fixes**
  * Admin accounts are no longer displayed in accessible employee results.

* **Improvements**
  * Walk-in list dates now display in a consistent format.
  * Long text fields in the walk-in table now use scrollable containers for better readability.

* **Documentation**
  * Updated API documentation for the accessible employees endpoint.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->